### PR TITLE
Fixed markdown error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ A Python library to check for (and clean) profanity in strings.
 ![Q-Bert spitting some profanity][logo]
 [logo]: http://i.imgur.com/kmz4Qx7.png
 
-##Installation
+## Installation
     pip install profanity
 
 
-##Usage
+## Usage
     from profanity import profanity
     profanity.contains_profanity("You smell like shit.")
     Out: True


### PR DESCRIPTION
Space added between '##' and 'Installation' and '##' and 'Usage' so it displays them as headings. Due to the continuous text that followed the '##' the headings were displayed alongside as normal text. This PR fixes the issue. 